### PR TITLE
Specify base period and return distribution parameters

### DIFF
--- a/standard_precip/base_sp.py
+++ b/standard_precip/base_sp.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import scipy.stats as scs
 import matplotlib.pyplot as plt
+from IPython import embed
 
 from standard_precip.lmoments import distr
 
@@ -117,8 +118,18 @@ class BaseStandardIndex():
             cdf = self.distrb.cdf(data, **params)
 
         # Apply inverse normal distribution
-        norm_ppf = scs.norm.ppf(cdf)
+        norm_ppf = scs.norm.ppf(cdf) # NH: find the inverse of the CDF except for a normal distribution
         norm_ppf[np.isinf(norm_ppf)] = np.nan
+
+        #########################
+        # diagnostics
+#        __import__("IPython").embed()
+#        from matplotlib import pyplot as plt
+#        # plot the CDF
+#        plt.plot(np.sort(data),np.sort(cdf))
+#        cdf_norm = scs.norm.cdf(norm_ppf)
+#        # plot the CDF of the normalised function
+#        plt.plot(np.sort(norm_ppf),np.sort(cdf_norm))
 
         return norm_ppf
 
@@ -243,6 +254,7 @@ class BaseStandardIndex():
                 )
 
                 # Calculate SPI/SPEI
+				# TODO: p_zero needs recalculating for the whole precip time series? Currently it's calculated using the base period only.
                 spi = self.cdf_to_ppf(precip_single, params, p_zero)
                 idx_col = f"{p}_calculated_index"
                 precip_single_df[idx_col] = spi

--- a/standard_precip/base_sp.py
+++ b/standard_precip/base_sp.py
@@ -218,6 +218,8 @@ class BaseStandardIndex():
         df: pd.Dataframe
             Pandas dataframe with the calculated indicies for each precipitation column appended
             to the original dataframe.
+		df_params: pd.DataFrame
+			Pandas dataframe with the distribution parameters for each calendar month.
         '''
 
         # Check for duplicate dates
@@ -248,6 +250,7 @@ class BaseStandardIndex():
         freq_range = self._df_copy[self.freq_col].unique().tolist()
         # Loop over months
         dfs = []
+        dictpar = dict.fromkeys(freq_range)
         for p in precip_cols:
             dfs_p = pd.DataFrame()
             for j in freq_range:
@@ -273,6 +276,7 @@ class BaseStandardIndex():
                 precip_single_df = precip_single_df[[date_col, idx_col]]
                 dfs_p = pd.concat([dfs_p, precip_single_df])
                 dfs_p = dfs_p.sort_values(date_col)
+                dictpar[j] = params
             dfs.append(dfs_p)
 
         df_all = reduce(
@@ -280,4 +284,4 @@ class BaseStandardIndex():
         )
         df_all = df_all.drop(columns=self.freq_col)
 
-        return df_all, params
+        return df_all, pd.DataFrame(dictpar).transpose()

--- a/standard_precip/base_sp.py
+++ b/standard_precip/base_sp.py
@@ -118,18 +118,27 @@ class BaseStandardIndex():
             cdf = self.distrb.cdf(data, **params)
 
         # Apply inverse normal distribution
-        norm_ppf = scs.norm.ppf(cdf) # NH: find the inverse of the CDF except for a normal distribution
+        norm_ppf = scs.norm.ppf(cdf) # NH: find the inverse of the CDF, except for a normal distribution
         norm_ppf[np.isinf(norm_ppf)] = np.nan
 
         #########################
         # diagnostics
+        #########################
+        # On PPF's and CDF's: https://www.itl.nist.gov/div898/handbook/eda/section3/eda362.htm
 #        __import__("IPython").embed()
+        # back calculate precip value from normalised data (i.e. from the SPI value)
+#        norm_cdf = scs.norm.cdf(norm_ppf)
+#        original_data = scs.gamma.ppf(norm_cdf,a=params['a'],loc=params['loc'],scale=params['scale'])
+
 #        from matplotlib import pyplot as plt
 #        # plot the CDF
 #        plt.plot(np.sort(data),np.sort(cdf))
 #        cdf_norm = scs.norm.cdf(norm_ppf)
 #        # plot the CDF of the normalised function
 #        plt.plot(np.sort(norm_ppf),np.sort(cdf_norm))
+        #########################
+        # end diagnostics
+        #########################
 
         return norm_ppf
 
@@ -254,7 +263,10 @@ class BaseStandardIndex():
                 )
 
                 # Calculate SPI/SPEI
-				# TODO: p_zero needs recalculating for the whole precip time series? Currently it's calculated using the base period only.
+                # NOTE: It's my understanding that p_zero does NOT need re-calculating based on the whole time series (as opposed to just 
+                # the base period above). ie. p_zero should represent the base period only, which is used to derive the parameters used in 
+                # the below CDF calcs. p_zero re-calculated using the whole time series would result in CDF's being calculated using 
+                # parameters from the baseline and a p_zero from the whole time series.
                 spi = self.cdf_to_ppf(precip_single, params, p_zero)
                 idx_col = f"{p}_calculated_index"
                 precip_single_df[idx_col] = spi
@@ -267,6 +279,5 @@ class BaseStandardIndex():
             lambda left, right: pd.merge(left, right, on=date_col, how='left'), dfs, self._df_copy
         )
         df_all = df_all.drop(columns=self.freq_col)
-#        df_all['params'] = params
 
         return df_all, params


### PR DESCRIPTION
Hi Eric, thanks for this tool. I was looking for a python package to calculate these metrics. I've added the ability to specify a base period (pretty fundamental for climate projection work). You do this by specifying "startyr" and "endyr" when calling spi.calculate(). Also the distribution parameters are returned for each calendar month. If you like, please review. I have a comment block or two that could be removed now that I see this MR, I can do that too no problem.