### PR TITLE
Loosen kap/mle regression gate to hardware-reproducible tolerance

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -36,6 +36,13 @@ def _load_golden():
 GOLDEN = _load_golden()
 FIT_KWARGS = {("gam", "mle"): {"floc": 0}, ("wei", "mle"): {"floc": 0}}
 
+DEFAULT_TOL = {"rel": 1e-9}
+TOLERANCES = {("kap", "mle"): {"abs": 1e-5}}
+"""scipy's kappa4 MLE converges to the same optimum with hardware-dependent
+floating-point drift around 1e-7 (observed across GitHub Actions runners), so
+kap/mle cannot hold the 1e-9 gate; 1e-5 still catches any real change, which
+alters values by 1e-3 or more."""
+
 
 @pytest.mark.parametrize("dist_type, fit_type", GOLDEN, ids=lambda v: v)
 def test_numerical_equivalence(monthly_df, dist_type, fit_type):
@@ -50,6 +57,7 @@ def test_numerical_equivalence(monthly_df, dist_type, fit_type):
         **FIT_KWARGS.get((dist_type, fit_type), {}),
     )
     assert result["date"].astype(str).tolist() == expected["date"].tolist()
+    tol = TOLERANCES.get((dist_type, fit_type), DEFAULT_TOL)
     assert result["TotalPrecipitation_calculated_index"].values == pytest.approx(
-        expected["index_value"].values, rel=1e-9, nan_ok=True
+        expected["index_value"].values, nan_ok=True, **tol
     )


### PR DESCRIPTION
Fixes the `test (3.13)` failure on the master CI run after #27 merged.

Not a Python 3.13 issue: the identical commit passed 3.13 on the PR run. The `kap-mle` regression test compares against golden values at rel=1e-9, but scipy's kappa4 MLE optimizer lands on the same optimum with hardware-dependent floating-point drift of ~1e-7 across runner CPU types (max abs diff on the failing run: 2.6e-7).

This gives that one combination an abs=1e-5 tolerance — still far below the 1e-3+ shift any genuine numerical change produces — and keeps every other (distribution, fit) combination at rel=1e-9. Documented inline in the test module.